### PR TITLE
Exclude vesting events past a grant cancellation from the Vesting History 

### DIFF
--- a/token-transfer-client/src/components/VestingBars.js
+++ b/token-transfer-client/src/components/VestingBars.js
@@ -113,9 +113,11 @@ const VestingBars = ({ user }) => {
               </div>
               {currencyGrants.map(grant => {
                 // Calculate the percentage of the grant that is complete with a
-                // upper bound of 100
+                // upper bound of 100. If the grant is cancelled, the completion stops once
+                // the current time is past the concellation date.
+                const tick = grant.cancelled && grant.cancelled < now ? grant.cancelled : now
                 const complete = Math.min(
-                  ((now - grant.start) / (grant.end - grant.start)) * 100,
+                  ((tick - grant.start) / (grant.end - grant.start)) * 100,
                   100
                 )
                 // Calculate the width of the grant relative to the width of the
@@ -216,7 +218,7 @@ const VestingBars = ({ user }) => {
                 <div className="status-circle mr-2"></div>
                 <span className=" text-muted">
                   {Number(data.totals.unvested[currency]).toLocaleString()}{' '}
-                  {currency} unvested
+                  {currency} unvested or cancelled
                 </span>
               </div>
             </div>

--- a/token-transfer-client/src/components/VestingBars.js
+++ b/token-transfer-client/src/components/VestingBars.js
@@ -115,9 +115,9 @@ const VestingBars = ({ user }) => {
                 // Calculate the percentage of the grant that is complete with a
                 // upper bound of 100. If the grant is cancelled, the completion stops once
                 // the current time is past the concellation date.
-                const tick = grant.cancelled && grant.cancelled < now ? grant.cancelled : now
+                const t = grant.cancelled && grant.cancelled < now ? grant.cancelled : now
                 const complete = Math.min(
-                  ((tick - grant.start) / (grant.end - grant.start)) * 100,
+                  ((t - grant.start) / (grant.end - grant.start)) * 100,
                   100
                 )
                 // Calculate the width of the grant relative to the width of the

--- a/token-transfer-client/src/components/VestingHistory.js
+++ b/token-transfer-client/src/components/VestingHistory.js
@@ -11,6 +11,9 @@ const VestingHistory = props => {
   const schedule = {}
   data.grants.forEach(grant => {
     vestingSchedule(props.user, grant).forEach(vest => {
+      // Do not include the vesting event if it has been cancelled.
+      if (vest.cancelled) return
+
       const dateKey = vest.date.format()
       if (schedule[dateKey] === undefined) schedule[dateKey] = {}
       schedule[dateKey][grant.currency] = schedule[dateKey][grant.currency]

--- a/token-transfer-server/src/lib/vesting.js
+++ b/token-transfer-server/src/lib/vesting.js
@@ -92,7 +92,8 @@ function employeeVestingSchedule(grantObj) {
       grantId: grantObj.id,
       amount: currentVestingEvent,
       date: vestingDate.clone(),
-      vested: hasVested(vestingDate, grant)
+      vested: hasVested(vestingDate, grant),
+      cancelled: isCancelled(vestingDate, grant),
     }
   })
   return events
@@ -135,7 +136,8 @@ function investorVestingSchedule(grantObj) {
     grantId: grantObj.id,
     amount: initialVestAmount,
     date: grant.start.clone(),
-    vested: hasVested(grant.start, grantObj)
+    vested: hasVested(grant.start, grantObj),
+    cancelled: isCancelled(grant.start, grant)
   })
 
   const vestingDate = grant.start.clone()
@@ -152,7 +154,8 @@ function investorVestingSchedule(grantObj) {
       grantId: grantObj.id,
       amount: i === 7 ? adjustedFinalVest : quarterlyVestAmount,
       date: vestingDate.clone(),
-      vested: hasVested(vestingDate, grant)
+      vested: hasVested(vestingDate, grant),
+      cancelled: isCancelled(vestingDate, grant)
     })
   }
 
@@ -164,6 +167,10 @@ function hasVested(vestingDate, grant) {
   return (
     vestingDate <= now && (!grant.cancelled || grant.cancelled >= vestingDate)
   )
+}
+
+function isCancelled(vestingDate, grant) {
+  return (grant.cancelled && grant.cancelled < vestingDate)
 }
 
 /** Returns the number of tokens vested by a grant.

--- a/token-transfer-server/test/api/lockup.test.js
+++ b/token-transfer-server/test/api/lockup.test.js
@@ -52,18 +52,18 @@ describe('Lockup HTTP API', () => {
       // Fully vested grant
       await Grant.create({
         userId: this.user.id,
-        start: moment().subtract(4, 'years'),
-        end: moment(),
-        cliff: moment().subtract(3, 'years'),
+        start: moment.utc().subtract(4, 'years'),
+        end: moment.utc(),
+        cliff: moment.utc().subtract(3, 'years'),
         currency: 'OGN',
         amount: 100000,
       }),
       // Vesting in the future
       await Grant.create({
         userId: this.user.id,
-        start: moment().add(1, 'years'),
-        end: moment().add(4, 'years'),
-        cliff: moment().add(1, 'years'),
+        start: moment.utc().add(1, 'years'),
+        end: moment.utc().add(4, 'years'),
+        cliff: moment.utc().add(1, 'years'),
         currency: 'OGN',
         amount: 10000000,
       }),

--- a/token-transfer-server/test/api/transfer.test.js
+++ b/token-transfer-server/test/api/transfer.test.js
@@ -55,9 +55,9 @@ describe('Transfer HTTP API', () => {
       await Grant.create({
         // Fully vested grant
         userId: this.user.id,
-        start: moment().subtract(4, 'years'),
-        end: moment(),
-        cliff: moment().subtract(3, 'years'),
+        start: moment.utc().subtract(4, 'years'),
+        end: moment.utc(),
+        cliff: moment.utc().subtract(3, 'years'),
         currency: 'OGN',
         amount: 1000000,
         interval: 'days',
@@ -65,19 +65,19 @@ describe('Transfer HTTP API', () => {
       await Grant.create({
         // Fully vested grant
         userId: this.user.id,
-        start: moment().subtract(4, 'years'),
-        end: moment(),
-        cliff: moment().subtract(3, 'years'),
-        currency: 'OGN',
+        start: moment.utc().subtract(4, 'years'),
+        end: moment.utc(),
+        cliff: moment.utc().subtract(3, 'years'),
+        currency: 'OGV',
         amount: 500000,
         interval: 'days',
       }),
       // Fully unvested grant
       await Grant.create({
         userId: this.user.id,
-        start: moment().add(10, 'years'),
-        end: moment().add(14, 'years'),
-        cliff: moment().add(11, 'years'),
+        start: moment.utc().add(10, 'years'),
+        end: moment.utc().add(14, 'years'),
+        cliff: moment.utc().add(11, 'years'),
         currency: 'OGN',
         amount: 10000000,
         interval: 'days',
@@ -85,9 +85,9 @@ describe('Transfer HTTP API', () => {
       // Grant for second user
       await Grant.create({
         userId: this.user2.id,
-        start: moment().subtract(6, 'months'),
-        end: moment().add(6, 'months').add(3, 'years'),
-        cliff: moment().add(6, 'months'),
+        start: moment.utc().subtract(6, 'months'),
+        end: moment.utc().add(6, 'months').add(3, 'years'),
+        cliff: moment.utc().add(6, 'months'),
         currency: 'OGN',
         amount: 20000,
         interval: 'days',
@@ -140,7 +140,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if unlock date has not passed', async () => {
-    const unlockFake = sinon.fake.returns(moment().add(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().add(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     const response = await request(this.mockApp)
@@ -176,7 +176,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should add a transfer if lockup date has passed', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     const sendStub = sinon.stub(sendgridMail, 'send')
@@ -200,7 +200,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer before lockup date passed', async () => {
-    const unlockFake = sinon.fake.returns(moment().add(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().add(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     const response = await request(this.mockApp)
@@ -221,7 +221,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if not enough tokens (vested)', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     const response = await request(this.mockApp)
@@ -258,7 +258,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if not enough tokens (vested minus enqueued)', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     await Transfer.create({
@@ -287,7 +287,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if not enough tokens (vested minus paused)', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     await Transfer.create({
@@ -316,7 +316,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if not enough tokens (vested minus waiting)', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     await Transfer.create({
@@ -345,7 +345,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if not enough tokens (vested minus success)', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     await Transfer.create({
@@ -374,7 +374,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if not enough tokens (multiple states)', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
 
     const promises = [
@@ -553,7 +553,7 @@ describe('Transfer HTTP API', () => {
   })
 
   it('should not add a transfer if unconfirmed lockups greater than balance', async () => {
-    const unlockFake = sinon.fake.returns(moment().subtract(1, 'days'))
+    const unlockFake = sinon.fake.returns(moment.utc().subtract(1, 'days'))
     transferController.__Rewire__('getUnlockDate', unlockFake)
     lockupController.__Rewire__('getUnlockDate', unlockFake)
 


### PR DESCRIPTION
Fix for #14 
- Added a new `cancelled` property on the vesting event object returned by the server. 
- The UI now checks on that property when using events in the VestingHistory and VestingBar component
- Added unit tests for the new code. Tweaked some older unit tests to use UTC tz otherwise they were failing when ran on a host in Daylight saving time :)

Here is a couple of snapshot showing the old vs new behavior with a grant having a cancellation date of 2021-06-15

**UI before** (notice how it shows vesting events past the cancellation date):
<img width="659" alt="Screenshot 2024-03-18 at 11 17 28 AM" src="https://github.com/OriginProtocol/t3/assets/945910/2cf61980-6adb-4669-ac9b-402d9eadb022">

**UI after** (notice how it dos not show vesting events past the cancellation date):
<img width="627" alt="Screenshot 2024-03-18 at 11 27 44 AM" src="https://github.com/OriginProtocol/t3/assets/945910/1b29a25c-4b92-465e-ac57-612724eea3be">

